### PR TITLE
[fix] : 파일 업로드 시 프론트에 파일 이름 S3 저장소에 올려진 파일 이름과 동일하게 주도록 변경

### DIFF
--- a/src/main/java/com/sparta/sunday/domain/attachment/service/AttachmentService.java
+++ b/src/main/java/com/sparta/sunday/domain/attachment/service/AttachmentService.java
@@ -57,11 +57,11 @@ public class AttachmentService {
         User user = User.fromAuthUser(authUser);
         Card card = cardRepository.findById(cardId).orElseThrow(() ->
                 new InvalidRequestException("Card not found"));
-        uploadFile(file,bucketName);
+        String fileName = uploadFile(file,bucketName);
         URL url = getUrl(bucketName, file.getOriginalFilename());
         UploadAttachmentResponse uploadAttachmentResponse = new UploadAttachmentResponse(
                 card.getId(),
-                file.getOriginalFilename(),
+                fileName,
                 user.getId(),
                 url
         );
@@ -107,7 +107,7 @@ public class AttachmentService {
 
     }
 
-    public void uploadFile(MultipartFile file,String bucketName) {
+    public String uploadFile(MultipartFile file,String bucketName) {
 
         String fileName = makeFileName(file);
 
@@ -117,6 +117,7 @@ public class AttachmentService {
 
         try {
             amazonS3Client.putObject(bucketName, fileName, file.getInputStream(), metadata);
+            return fileName;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/sparta/sunday/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/sparta/sunday/domain/card/repository/CardRepository.java
@@ -2,7 +2,6 @@ package com.sparta.sunday.domain.card.repository;
 
 import com.sparta.sunday.domain.card.entity.Card;
 import com.sparta.sunday.domain.list.entity.BoardList;
-import com.sparta.sunday.domain.card.entity.CardManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;


### PR DESCRIPTION
1. 기존 파일 업로드 시 프론트에 fileName 이 S3 데이터의 이름과 다른 문제 해결